### PR TITLE
fix reading of tiled tiffs

### DIFF
--- a/iio.c
+++ b/iio.c
@@ -1480,7 +1480,7 @@ static int read_whole_tiff(struct iio_image *x, const char *filename)
 			}
 		}
 		xfree(tbuf);
-	} else
+	} else {
 
 	// dump scanline data
 	if (broken && bps < 8) fail("cannot unpack broken scanlines");
@@ -1511,6 +1511,7 @@ static int read_whole_tiff(struct iio_image *x, const char *filename)
 					w, spp, bps/8);
 		}
 	}
+    }
 	TIFFClose(tif);
 
 


### PR DESCRIPTION
The current version of iio crashes when trying to read tiled tiff files.

The bug was introduced in commit 0b5c9b by adding a second line after an else statement without enclosing curly braces.