### PR TITLE
fix orientation when a tiff image is considered weird

### DIFF
--- a/contrib/python/iio-0.0.3/iio/iio.c
+++ b/contrib/python/iio-0.0.3/iio/iio.c
@@ -1630,7 +1630,7 @@ static int read_whole_tiff(struct iio_image *x, const char *filename)
 		x->pixel_dimension = 4;
 		x->type = IIO_TYPE_UINT8;
 		x->data = xmalloc(w*h*4);
-		r = TIFFReadRGBAImage(tif, w, h, (uint32_t*)x->data, 0);
+		r = TIFFReadRGBAImageOriented(tif, w, h, (uint32_t*)x->data, ORIENTATION_TOPLEFT, 0);
 		IIO_DEBUG("\tr = %d\n", r);
 		if (!r) fail("TIFFReadRGBAImage(\"%s\") failed\n", filename);
 		x->contiguous_data = false;


### PR DESCRIPTION
By default the orientation is ORIENTATION_BOTLEFT (http://www.libtiff.org/man/TIFFReadRGBAImage.3t.html).